### PR TITLE
SDE-96: S3 files weren't expiring

### DIFF
--- a/aws-infrastructure/modules/s3/main.tf
+++ b/aws-infrastructure/modules/s3/main.tf
@@ -9,12 +9,6 @@ resource "aws_s3_bucket" "sde-bucket" {
     expiration {
       days = "1"
     }
-
-    tags = {
-      Name = "${var.name_prefix}-one-day-life"
-      Environment = var.environment
-      Project     = var.project
-    }
   }
 
   tags = {


### PR DESCRIPTION
Incorrectly set rule to only expire files matching tags. The tags shouldn't be part of the expiry rule!