### PR TITLE
SDE-118 change return from text to json

### DIFF
--- a/graphical-report-api/index.js
+++ b/graphical-report-api/index.js
@@ -40,7 +40,7 @@ exports.handler = async (event, _, callback) => {
       statusCode: '400',
       body: JSON.stringify({
         message: 'Error In Generation',
-        errorMessage: JSON.stringify(error.message),
+        errorMessage: error.message,
         content: event.body
       }),
       headers: callbackHeaders

--- a/hybrid-report-api/index.js
+++ b/hybrid-report-api/index.js
@@ -41,7 +41,7 @@ exports.handler = async (event, context, callback) => {
       statusCode: '400',
       body: JSON.stringify({
         message: 'Error In Generation',
-        errorMessage: JSON.stringify(error.message),
+        errorMessage: error.message,
         content: event.body
       }),
       headers: callbackHeaders


### PR DESCRIPTION
The return types from the current Lambda reports were in plain text. Added conversion into JSON on the return data, required for front end to extract data easily. 