### PR TITLE
SDE-119 add content-disposition to all saves

### DIFF
--- a/graphical-report-api/common/s3-output.js
+++ b/graphical-report-api/common/s3-output.js
@@ -20,6 +20,7 @@ class S3Output {
         Bucket: this._bucketName,
         Key: filename,
         ContentType: 'image/svg+xml',
+        ContentDisposition: 'download; fileName="Chart.svg"',
         Body: Buffer.from(this._reportBuffer, 'ascii'),
         ACL: 'public-read'
       })

--- a/hybrid-report-api/common/s3-output.js
+++ b/hybrid-report-api/common/s3-output.js
@@ -18,6 +18,7 @@ class S3Output {
       Bucket: this._bucketName,
       Key: filename,
       ContentType: 'application/pdf',
+      ContentDisposition: 'download; fileName="Report.pdf"',
       Body: this._reportBuffer,
       ACL: 'public-read'
     }).promise();

--- a/report-generator-api/app/s3-output.js
+++ b/report-generator-api/app/s3-output.js
@@ -22,6 +22,7 @@ class S3Output {
       Bucket: this._bucketName,
       Key: filename,
       ContentType: 'text/csv',
+      ContentDisposition: 'download; fileName="Report.csv"',
       Body: Buffer.from(this._reportBuffer, 'ascii'),
       ACL: 'public-read'
     }).promise();


### PR DESCRIPTION
Added a default content-disposition to all S3 bucket saves, which should force a users machine to download the file instead of trying to display on screen. This bypasses the need for client size to be changed. 

Effected areas
+ Graphical Report
+ Hybrid Report
+ CSV Saves
