### PR TITLE
sde-155 use cognito email for to address

### DIFF
--- a/functions/downloadRequest.js
+++ b/functions/downloadRequest.js
@@ -33,15 +33,14 @@ export async function handler(event) {
   try {
     validateRequestHeaders(event);
 
-    const { type } = JSON.parse(event.body);
     const bodyJSON = JSON.parse(event.body);
+    const { type } = bodyJSON;
 
     const startExecutionParams = {
       stateMachineArn: stepFunctionArn,
       input: JSON.stringify({
         ...bodyJSON,
         parameters: {
-          ...bodyJSON.parameters,
           emailAddress: event.requestContext.authorizer.claims.email
         }
       })


### PR DESCRIPTION
Changes to Download request lambda to use the users email from Cognito to be used as the to address. 
