### PR TITLE
SDE-158 change input model for download request

### DIFF
--- a/api_models/DownloadRequestInputModel.json
+++ b/api_models/DownloadRequestInputModel.json
@@ -2,10 +2,9 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "DownloadRequestInputModel",
   "type": "object",
-  "required": ["type", "parameters", "searchCriteria"],
+  "required": ["type", "searchCriteria"],
   "properties": {
     "type": { "type": "string", "enum": ["direct", "push", "email"] },
-    "parameters": { "type": ["object", "null"] },
     "searchCriteria": { "type": "object" }
   }
 }


### PR DESCRIPTION
Update back end validation schema for download request, due to `parameters` no longer being required. 
+ Removes the parameters from being required on download request calls to the API gateway. 