### PR TITLE
SDE-163 Changed all reports to return signed URL's

### DIFF
--- a/common/graphicalReport/s3-output.js
+++ b/common/graphicalReport/s3-output.js
@@ -1,6 +1,6 @@
 import { S3 } from 'aws-sdk';
 import uuidv4 from 'uuid/v4';
-import { fileTimeout } from '../s3_expiry';
+import { fileTimeout, signedUrlTimeout } from '../s3_expiry';
 
 class S3Output {
   constructor(bucketName) {
@@ -23,12 +23,15 @@ class S3Output {
         ContentType: 'image/svg+xml',
         ContentDisposition: `${downloadMode && 'download;'} fileName="Chart.svg"`,
         Body: Buffer.from(this._reportBuffer, 'ascii'),
-        ACL: 'public-read',
         Expires: fileTimeout()
       })
       .promise();
 
-    return `https://${this._bucketName}.s3.amazonaws.com/${filename}`;
+    return s3.getSignedUrl('getObject', {
+      Bucket: this._bucketName,
+      Key: filename,
+      Expires: signedUrlTimeout()
+    });
   }
 
   async close(downloadMode) {

--- a/common/hybridReport/s3-output.js
+++ b/common/hybridReport/s3-output.js
@@ -1,6 +1,6 @@
 import { S3 } from 'aws-sdk';
 import uuidv4 from 'uuid/v4';
-import { fileTimeout } from '../s3_expiry';
+import { fileTimeout, signedUrlTimeout } from '../s3_expiry';
 
 class S3Output {
   constructor(bucketName) {
@@ -21,11 +21,14 @@ class S3Output {
       ContentType: 'application/pdf',
       ContentDisposition: 'download; fileName="Report.pdf"',
       Body: this._reportBuffer,
-      ACL: 'public-read',
       Expires: fileTimeout()
     }).promise();
 
-    return `https://${this._bucketName}.s3.amazonaws.com/${filename}`;
+    return s3.getSignedUrl('getObject', {
+      Bucket: this._bucketName,
+      Key: filename,
+      Expires: signedUrlTimeout()
+    });
   }
 
   async close() {

--- a/common/reportGenerator/report-generator.js
+++ b/common/reportGenerator/report-generator.js
@@ -1,8 +1,8 @@
-const AWS = require('aws-sdk');
-const connectionClass = require('http-aws-es');
-const { Client } = require('elasticsearch');
-const buildQueryJson = require('../query.js');
-const Formatter = require('./csv-formatter');
+import { Config, EnvironmentCredentials } from 'aws-sdk';
+import connectionClass from 'http-aws-es';
+import { Client } from 'elasticsearch';
+import buildQueryJson from '../query';
+import { formatRows, formatHeader } from './csv-formatter';
 
 // this should be much higher number (10000), but set low to demonstrate scroll / multi-part upload
 const scrollResultSize = 10;
@@ -10,8 +10,8 @@ const scrollResultSize = 10;
 const getConfig = () => ({
   host: process.env.ES_SEARCH_API,
   connectionClass,
-  awsConfig: new AWS.Config({
-    credentials: new AWS.EnvironmentCredentials('AWS')
+  awsConfig: new Config({
+    credentials: new EnvironmentCredentials('AWS')
   })
 });
 
@@ -55,7 +55,7 @@ class ReportGenerator {
     let currentScrollId = result._scroll_id;
 
     while (hits && hits.hits.length) {
-      this.emitRows(Formatter.formatRows(result));
+      this.emitRows(formatRows(result));
 
       // eslint-disable-next-line no-await-in-loop
       const scrollResult = await this.doScroll(currentScrollId);
@@ -72,7 +72,7 @@ class ReportGenerator {
 
     const searchResult = await this.doSearch(searchJSON);
 
-    this.emitHeader(Formatter.formatHeader(searchResult));
+    this.emitHeader(formatHeader(searchResult));
 
     await this.processBatch(searchResult);
 
@@ -88,4 +88,4 @@ class ReportGenerator {
   }
 }
 
-module.exports = ReportGenerator;
+export default ReportGenerator;

--- a/common/s3_expiry.js
+++ b/common/s3_expiry.js
@@ -1,5 +1,13 @@
+function getTimeoutHours() {
+  return (process.env.S3_OBJECT_TIMEOUT || 1);
+}
+
 export function fileTimeout() {
   const expireDate = new Date(Date.now());
-  expireDate.setHours(expireDate.getHours() + (process.env.S3_OBJECT_TIMEOUT || 1));
+  expireDate.setHours(expireDate.getHours() + getTimeoutHours());
   return expireDate;
+}
+
+export function signedUrlTimeout() {
+  return getTimeoutHours() * 60 * 60;
 }

--- a/functions/reportGenerator.js
+++ b/functions/reportGenerator.js
@@ -1,7 +1,7 @@
-const ReportGenerator = require('../common/reportGenerator/report-generator');
-const S3Output = require('../common/reportGenerator/s3-output.js');
+import ReportGenerator from '../common/reportGenerator/report-generator';
+import S3Output from '../common/reportGenerator/s3-output';
 
-exports.handler = async (event) => {
+export async function handler(event) {
   console.log(`event\n${JSON.stringify(event, null, 2)}`);
 
   const reportGenerator = new ReportGenerator(new S3Output(process.env.S3_BUCKET_NAME));
@@ -9,4 +9,4 @@ exports.handler = async (event) => {
   const reportURL = await reportGenerator.generate(event.searchCriteria);
 
   return { reportURL };
-};
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -44,6 +44,7 @@ provider:
         - states:GetActivityTask
         - execute-api:Invoke
         - es:ESHttpPost
+        - s3:GetObject
         - s3:PutObject
         - s3:PutObjectAcl
         - ses:SendEmail


### PR DESCRIPTION
This is part of Story SDE-157.

Changes:

For all reports, we return a signed URL rather than simply the file URL. The timeout on the signed URL is will also be the same as the timeout for the S3 file.
For all reports, removed the ACL stating it's public-read, so files are now all private.
Allow s3:GetObject for all Lambdas (this had me stuck for ages)
Refactored require into imports