### PR TITLE
SDE-164 - make download bucket private (default behaviour)

### DIFF
--- a/aws-infrastructure/modules/s3/main.tf
+++ b/aws-infrastructure/modules/s3/main.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "sde-bucket" {
   bucket = "${var.name_prefix}-scott-logic"
-  acl = "public-read"
 
   lifecycle_rule {
     id = "${var.name_prefix}-one-day-life"


### PR DESCRIPTION
Given that we now give access via signed URL's, this bucket can be completely private. 