### PR TITLE
SDE - fix issue on hybrid cold start generation

### DIFF
--- a/common/hybridReport/hybridGenerator.js
+++ b/common/hybridReport/hybridGenerator.js
@@ -47,7 +47,7 @@ class HybridGenerator {
       headless: chrome.headless,
     });
     const page = await browser.newPage();
-    page.setContent(formattedHTML);
+    await page.setContent(formattedHTML);
     const buffer = await page.pdf({
       format: 'A4'
     });


### PR DESCRIPTION
Fix an issue with cold starting lambdas and puppeteer, an await was needed to set the content of the document to make sure it was all loaded into the page before exporting. 